### PR TITLE
Hotfix: Schedule Diagram Break Outline

### DIFF
--- a/src/components/schedule/diagram.tsx
+++ b/src/components/schedule/diagram.tsx
@@ -36,10 +36,10 @@ const ScheduleDiagramItem = ({
         className={`h-full w-full rounded-full ${
           scheduleItem.relevant
             ? scheduleItem.break
-              ? "outline outline-2 outline-light-secondary outline-offset-[-2px]"
+              ? "outline outline-2 outline-light-secondary dark:outline-dark-on-secondary outline-offset-[-2px]"
               : "bg-light-secondary dark:bg-dark-secondary"
             : scheduleItem.break
-            ? "outline outline-2 outline-light-on-secondary outline-offset-[-2px]"
+            ? "outline outline-2 outline-light-on-secondary dark:outline-dark-on-secondary outline-offset-[-2px]"
             : "bg-light-on-secondary dark:bg-dark-on-secondary"
         }`}
       ></div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -109,7 +109,7 @@ module.exports = {
         none: "0",
         xs: "0.03125rem",
         sm: "0.25rem",
-        default: "0.5rem",
+        DEFAULT: "0.5rem",
         lg: "0.75rem",
         xl: "0.9375rem",
         "2xl": "1.75rem",


### PR DESCRIPTION
The colour of the outline for break periods in the Schedule Diagram wasn't adapting to dark mode.

**Issue:**
![image](https://user-images.githubusercontent.com/26425747/149816193-4688e833-5274-4cad-ba8d-a129fb8fffbb.png)

**Resolution:**
![image](https://user-images.githubusercontent.com/26425747/149816388-898bf454-48dc-456f-bf93-9a32ceca0369.png)
